### PR TITLE
Fix PHPCS warnings about strict mode for in_array

### DIFF
--- a/inc/class-img-shortcode.php
+++ b/inc/class-img-shortcode.php
@@ -211,7 +211,7 @@ class Img_Shortcode {
 
 		// If a link is specified, wrap the image in a link tag
 		if ( ! empty( $attr['linkto'] ) &&
-				( in_array( $attr['linkto'], array( 'file', 'attachment' ) ) ||
+				( in_array( $attr['linkto'], array( 'file', 'attachment' ), true ) ||
 				( 'custom' === $attr['linkto'] && ! empty( $attr['url'] ) ) ) ) {
 			$image_html = self::linkify( $image_html, $attr );
 		}


### PR DESCRIPTION
Addresses new WPCS sniff from https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/399