### PR TITLE
Add "encode => true" to alt and caption fields

### DIFF
--- a/inc/class-img-shortcode.php
+++ b/inc/class-img-shortcode.php
@@ -150,24 +150,28 @@ class Img_Shortcode {
 	 *
 	 * @param array $attrs Shortcode attributes. See definitions in
 	 *                     @function `get_shortcode_ui_args()`
+	 * @param (not used)   Inner content argument
+	 * @param string $shortcode_tag
 	 * @return string
 	 */
-	public static function callback( $attr ) {
+	public static function callback( $attr, $_null, $shortcode_tag ) {
 
-		$attr = wp_parse_args( $attr, array(
-			'attachment' => 0,
-			'size'       => 'full',
-			'alt'        => '',
-			'classes'    => '',
-			'caption'    => '',
-			'align'      => 'alignnone',
-			'linkto'     => '',
-		) );
+		$attr = shortcode_atts(
+			array(
+				'attachment' => 0,
+				'size'       => 'full',
+				'alt'        => '',
+				'classes'    => '',
+				'caption'    => '',
+				'align'      => 'alignnone',
+				'linkto'     => '',
+			), $attr, $shortcode_tag
+		);
 
 		/**
+		 * Filter the shortcode attributes before rendering
 		 *
-		 *
-		 * @param
+		 * @param array Shortcode attributes, decoded and merged with defaults.
 		 */
 		$attr = apply_filters( 'img_shortcode_attrs', $attr );
 

--- a/inc/class-img-shortcode.php
+++ b/inc/class-img-shortcode.php
@@ -156,17 +156,19 @@ class Img_Shortcode {
 	 */
 	public static function callback( $attr, $_null, $shortcode_tag ) {
 
-		$attr = shortcode_atts(
+		// Get all registered args; shortcode_atts() needs a whitelist of args
+		$shortcode_args = static::get_shortcode_ui_args();
+		$registered_atts = array_fill_keys( wp_list_pluck( $shortcode_args['attrs'], 'attr' ), null );
+		$args_with_defaults = array_merge( $registered_atts,
 			array(
-				'attachment' => 0,
+				'src'        => null,
 				'size'       => 'full',
-				'alt'        => '',
 				'classes'    => '',
-				'caption'    => '',
 				'align'      => 'alignnone',
-				'linkto'     => '',
-			), $attr, $shortcode_tag
+			)
 		);
+
+		$attr = shortcode_atts( $args_with_defaults, $attr, $shortcode_tag );
 
 		/**
 		 * Filter the shortcode attributes before rendering

--- a/inc/class-img-shortcode.php
+++ b/inc/class-img-shortcode.php
@@ -70,6 +70,7 @@ class Img_Shortcode {
 						'label'       => esc_html__( 'Alt', 'image-shortcake' ),
 						'attr'        => 'alt',
 						'type'        => 'text',
+						'encode'      => true,
 						'placeholder' => esc_attr__( 'Alt text for the image', 'image-shortcake' ),
 						'description' => esc_html__( 'Double quotes and HTML tags are not allowed', 'image-shortcake' ),
 					),
@@ -78,8 +79,8 @@ class Img_Shortcode {
 						'label'       => esc_html__( 'Caption', 'image-shortcake' ),
 						'attr'        => 'caption',
 						'type'        => 'text',
+						'encode'      => true,
 						'placeholder' => esc_attr__( 'Caption for the image', 'image-shortcake' ),
-						'description' => esc_html__( 'Double quotes and HTML tags are not allowed', 'image-shortcake' ),
 					),
 
 					array(

--- a/inc/class-img-shortcode.php
+++ b/inc/class-img-shortcode.php
@@ -215,8 +215,8 @@ class Img_Shortcode {
 
 		// If a link is specified, wrap the image in a link tag
 		if ( ! empty( $attr['linkto'] ) &&
-				( in_array( $attr['linkto'], array( 'file', 'attachment' ), true ) ||
-				( 'custom' === $attr['linkto'] && ! empty( $attr['url'] ) ) ) ) {
+			( in_array( $attr['linkto'], array( 'file', 'attachment' ), true ) ||
+			( 'custom' === $attr['linkto'] && ! empty( $attr['url'] ) ) ) ) {
 			$image_html = self::linkify( $image_html, $attr );
 		}
 

--- a/inc/class-img-shortcode.php
+++ b/inc/class-img-shortcode.php
@@ -72,7 +72,6 @@ class Img_Shortcode {
 						'type'        => 'text',
 						'encode'      => true,
 						'placeholder' => esc_attr__( 'Alt text for the image', 'image-shortcake' ),
-						'description' => esc_html__( 'Double quotes and HTML tags are not allowed', 'image-shortcake' ),
 					),
 
 					array(

--- a/inc/class-img-shortcode.php
+++ b/inc/class-img-shortcode.php
@@ -217,7 +217,7 @@ class Img_Shortcode {
 		if ( ! empty( $attr['linkto'] ) &&
 			( in_array( $attr['linkto'], array( 'file', 'attachment' ), true ) ||
 			( 'custom' === $attr['linkto'] && ! empty( $attr['url'] ) ) ) ) {
-			$image_html = self::linkify( $image_html, $attr );
+				$image_html = self::linkify( $image_html, $attr );
 		}
 
 		/**


### PR DESCRIPTION
Since Shortcake added support for URL-encoding attribute values (https://github.com/wp-shortcake/shortcake/pull/496), we can remove the unfriendly admonitions to avoid using quote marks, branckets, or HTML in the alt and caption fields here by passing "encode" => true in the attribute registration.

#42