### PR TITLE
URL encode alt and description when sent from media editor

### DIFF
--- a/inc/class-img-shortcode.php
+++ b/inc/class-img-shortcode.php
@@ -365,8 +365,9 @@ class Img_Shortcode {
 			'width' => 'width',
 		);
 
+		$shortcode_ui_def = self::get_shortcode_ui_args();
 		$encoded_attributes = wp_list_pluck(
-			array_filter( self::get_shortcode_ui_args()['attrs'], function( $attr ) {
+			array_filter( $shortcode_ui_def['attrs'], function( $attr ) {
 				return ! empty( $attr['encode'] ) && $attr['encode'];
 			} ),
 			'attr'
@@ -374,7 +375,7 @@ class Img_Shortcode {
 
 		foreach ( $allowed_attrs as $attachment_attr => $shortcode_attr ) {
 			if ( ! empty( $attachment[ $attachment_attr ] ) ) {
-				$shortcode_attrs[ $shortcode_attr ] = in_array( $shortcode_attr, $encoded_attributes ) ?
+				$shortcode_attrs[ $shortcode_attr ] = in_array( $shortcode_attr, $encoded_attributes, true ) ?
 					urlencode( $attachment[ $attachment_attr ] ) : $attachment[ $attachment_attr ];
 			}
 		}

--- a/inc/class-img-shortcode.php
+++ b/inc/class-img-shortcode.php
@@ -365,9 +365,17 @@ class Img_Shortcode {
 			'width' => 'width',
 		);
 
+		$encoded_attributes = wp_list_pluck(
+			array_filter( self::get_shortcode_ui_args()['attrs'], function( $attr ) {
+				return ! empty( $attr['encode'] ) && $attr['encode'];
+			} ),
+			'attr'
+		);
+
 		foreach ( $allowed_attrs as $attachment_attr => $shortcode_attr ) {
 			if ( ! empty( $attachment[ $attachment_attr ] ) ) {
-				$shortcode_attrs[ $shortcode_attr ] = $attachment[ $attachment_attr ];
+				$shortcode_attrs[ $shortcode_attr ] = in_array( $shortcode_attr, $encoded_attributes ) ?
+					urlencode( $attachment[ $attachment_attr ] ) : $attachment[ $attachment_attr ];
 			}
 		}
 

--- a/tests/test-img-shortcode.php
+++ b/tests/test-img-shortcode.php
@@ -116,11 +116,11 @@ EOL;
 			$attachment_data,
 			array(
 				'id'           => $attachment_id,
-				'post_content' => 'This is the description',
-				'post_excerpt' => 'This is the caption',
+				'post_content' => 'This is the "description"',
+				'post_excerpt' => 'This is the [caption]',
 				'align'        => 'right',
 				'image-size'   => 'large',
-				'image_alt'    => 'This is the alt',
+				'image_alt'    => 'This is the \'alt\'',
 				'url'          => get_permalink( $attachment_id ),
 			)
 		);
@@ -130,7 +130,8 @@ EOL;
 		$this->assertContains( '[img ', $shortcode );
 		$this->assertContains( 'size="large"', $shortcode );
 		$this->assertContains( 'align="alignright"', $shortcode );
-		$this->assertContains( 'caption="This is the caption"', $shortcode );
+		$this->assertContains( 'alt="This+is+the+%27alt%27"', $shortcode );
+		$this->assertContains( 'caption="This+is+the+%5Bcaption%5D"', $shortcode );
 
 	}
 


### PR DESCRIPTION
When fields containing disallowed characters are sent from the media
modal to the editor, their values should be urlencoded before being
inserted as a shortcode, to prevent breaking the shortcode parser.

The remaining piece of #42.