### PR TITLE
Actually this needs to be `rawurlencode()`

### DIFF
--- a/inc/class-img-shortcode.php
+++ b/inc/class-img-shortcode.php
@@ -376,7 +376,7 @@ class Img_Shortcode {
 		foreach ( $allowed_attrs as $attachment_attr => $shortcode_attr ) {
 			if ( ! empty( $attachment[ $attachment_attr ] ) ) {
 				$shortcode_attrs[ $shortcode_attr ] = in_array( $shortcode_attr, $encoded_attributes, true ) ?
-					urlencode( $attachment[ $attachment_attr ] ) : $attachment[ $attachment_attr ];
+					rawurlencode( $attachment[ $attachment_attr ] ) : $attachment[ $attachment_attr ];
 			}
 		}
 

--- a/tests/test-img-shortcode.php
+++ b/tests/test-img-shortcode.php
@@ -130,8 +130,8 @@ EOL;
 		$this->assertContains( '[img ', $shortcode );
 		$this->assertContains( 'size="large"', $shortcode );
 		$this->assertContains( 'align="alignright"', $shortcode );
-		$this->assertContains( 'alt="This+is+the+%27alt%27"', $shortcode );
-		$this->assertContains( 'caption="This+is+the+%5Bcaption%5D"', $shortcode );
+		$this->assertContains( 'alt="This%20is%20the%20%27alt%27"', $shortcode );
+		$this->assertContains( 'caption="This%20is%20the%20%5Bcaption%5D"', $shortcode );
 
 	}
 


### PR DESCRIPTION
My mistake in #68 - I wasn't understanding the difference between `rawurlencode` and `urlencode`, and as a result I didn't catch the mismatch until writing my integration tests elsewhere. 

This replaces the `urlencode()` filter on encoded fields sent to the editor with `rawurlencode()` which matches the way these fields are decoded on display.

Part of #42.