### PR TITLE
Overload `wp.media.editor.send` to send linkto and linkUrl fields

### DIFF
--- a/inc/class-img-shortcode.php
+++ b/inc/class-img-shortcode.php
@@ -362,7 +362,8 @@ class Img_Shortcode {
 			'image-size' => 'size',
 			'image_alt' => 'alt',
 			'post_excerpt' => 'caption',
-			'width' => 'width',
+			'linkto' => 'linkto',
+			'url' => 'url'
 		);
 
 		$shortcode_ui_def = self::get_shortcode_ui_args();

--- a/inc/class-img-shortcode.php
+++ b/inc/class-img-shortcode.php
@@ -381,6 +381,10 @@ class Img_Shortcode {
 			}
 		}
 
+		if ( ! empty( $shortcode_attrs['linkto'] ) && 'post' === $shortcode_attrs['linkto'] ) {
+			$shortcode_attrs['linkto'] = 'attachment';
+		}
+
 		/**
 		 * Filter the shortcode attributes when inserting image from the media library.
 		 *


### PR DESCRIPTION
Based off code by @vralle at https://gist.github.com/vralle/b0db1083f1c8e392527e

I wanted a way to tap into the `wp.media.editor.send.attachment` functionality which didn't completely break the connection to core's functionality. This is the best I could come up with for now - temporarily redefining the ajax method so that the post data can be modified before posting to admin-ajax.  

The benefits of this approach over just copy-pasting the `wp.media.editor.send.attachment` functionality from core are that:
* we're not preventing other plugins from also tapping into this method
* we don't cut ourselves off from core's functionality, so that if this method is updated in core, we still get to use the core function

See #65

