### PR TITLE
Define Composer `wordpress-plugin` package type

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
       "email": "tech@fusion.net"
     }
   ],
+  "type": "wordpress-plugin",
   "require-dev": {
     "wp-coding-standards/wpcs": "dev-develop"
   },


### PR DESCRIPTION
This allows users to easily [manage this plugin as a Composer dependency](https://roots.io/wordpress-plugins-with-composer/) in the same way that the main Shortcake plugin does.

Related to https://github.com/wp-shortcake/shortcake-bakery/pull/186