### PR TITLE
Add an isset check in case there aren't additional image sizes

### DIFF
--- a/inc/class-img-shortcode.php
+++ b/inc/class-img-shortcode.php
@@ -31,7 +31,7 @@ class Img_Shortcode {
 			$size = get_option( "${key}_size_w" );
 
 			if ( false === $size ) {
-				if ( array_key_exists( $key, $_wp_additional_image_sizes ) ) {
+				if ( isset( $_wp_additional_image_sizes ) && array_key_exists( $key, $_wp_additional_image_sizes ) ) {
 					$size = $_wp_additional_image_sizes[ $key ]['width'];
 				}
 			}


### PR DESCRIPTION
Currently If there are no additional image sizes you will see the following warning:
 ```
Warning: array_key_exists() expects parameter 2 to be array, null given in /vagrant/content/mu-plugins/vendor/image-shortcake/inc/class-img-shortcode.php on line 34
```

This PR resolves this issue.