### PR TITLE
Remove PHP 5.3 from Travis matrix, add PHP7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,17 +6,15 @@ notifications:
   on_success: never
   on_failure: change
 
-php:
-  - 5.3
-  - 5.5
-
 env:
   - WP_VERSION=latest WP_MULTISITE=0
 
 matrix:
   include:
-    - php: 5.3
+    - php: 5.6
       env: WP_VERSION=latest WP_MULTISITE=1
+    - php: 7.1
+	  env: WP_VERSION=latest WP_MULTISITE=0
 
 cache:
   - composer
@@ -25,7 +23,7 @@ cache:
 before_script:
   - composer install
   - npm install
-  - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION 
+  - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
 
 script:
   - grunt phpcs

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
     - php: 5.6
       env: WP_VERSION=latest WP_MULTISITE=1
     - php: 7.1
-	  env: WP_VERSION=latest WP_MULTISITE=0
+      env: WP_VERSION=latest WP_MULTISITE=0
 
 cache:
   - composer

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,6 @@ sudo: false
 
 language: php
 
-notifications:
-  on_success: never
-  on_failure: change
-
-env:
-  - WP_VERSION=latest WP_MULTISITE=0
-
 matrix:
   include:
     - php: 5.6
@@ -17,8 +10,9 @@ matrix:
       env: WP_VERSION=latest WP_MULTISITE=0
 
 cache:
-  - composer
-  - npm
+  directories:
+    - vendor
+    - node_modules
 
 before_script:
   - composer install
@@ -28,3 +22,7 @@ before_script:
 script:
   - grunt phpcs
   - phpunit
+
+branches:
+  only:
+    - master

--- a/inc/class-img-shortcode-data-migration.php
+++ b/inc/class-img-shortcode-data-migration.php
@@ -32,7 +32,7 @@ class Img_Shortcode_Data_Migration {
 	private static function caption_shortcode_regex() {
 		$caption_shortcode_regex =
 			'\[caption' .
-				'[^\]]*' .  '\]\]?' .
+				'[^\]]*' . '\]\]?' .
 				self::img_shortcode_regex() .
 				'(?: (?P<caption>[^\]]*))' .
 			'\[\[?\/caption\]\]?';
@@ -40,7 +40,8 @@ class Img_Shortcode_Data_Migration {
 	}
 
 	public static function find_img_tags_for_replacement_on_post( $post ) {
-		if ( ! $post = self::maybe_get_post_from_id( $post ) ) {
+		$post = self::maybe_get_post_from_id( $post );
+		if ( ! $post ) {
 			return false;
 		}
 
@@ -82,7 +83,8 @@ class Img_Shortcode_Data_Migration {
 
 
 	public static function find_caption_shortcodes_for_replacement_on_post( $post ) {
-		if ( ! $post = self::maybe_get_post_from_id( $post ) ) {
+		$post = self::maybe_get_post_from_id( $post );
+		if ( ! $post ) {
 			return false;
 		}
 
@@ -157,7 +159,7 @@ class Img_Shortcode_Data_Migration {
 
 				if ( get_permalink( (int) $attributes['attachment'] ) === $attributes['href'] ) {
 					$shortcode_attrs['linkto'] = 'attachment';
-				} else if ( $attachment_src[0] === $attributes['href'] // link to full size image
+				} elseif ( $attachment_src[0] === $attributes['href'] // link to full size image
 						|| $attributes['src'] === $attributes['href'] // link the same as image src
 						) {
 					$shortcode_attrs['linkto'] = 'file';

--- a/inc/class-img-shortcode.php
+++ b/inc/class-img-shortcode.php
@@ -43,79 +43,79 @@ class Img_Shortcode {
 
 		$shortcode_ui_args = array(
 
-				'label' => esc_html__( 'Image', 'image-shortcake' ),
+			'label' => esc_html__( 'Image', 'image-shortcake' ),
 
-				'listItemImage' => 'dashicons-format-image',
+			'listItemImage' => 'dashicons-format-image',
 
-				'attrs' => array(
+			'attrs' => array(
 
-					array(
-						'label' => esc_html__( 'Choose Attachment', 'image-shortcake' ),
-						'attr'  => 'attachment',
-						'type'  => 'attachment',
-						'libraryType' => array( 'image' ),
-						'addButton'   => esc_attr__( 'Select Image', 'image-shortcake' ),
-						'frameTitle'  => esc_attr__( 'Select Image', 'image-shortcake' ),
-					),
+				array(
+					'label' => esc_html__( 'Choose Attachment', 'image-shortcake' ),
+					'attr'  => 'attachment',
+					'type'  => 'attachment',
+					'libraryType' => array( 'image' ),
+					'addButton'   => esc_attr__( 'Select Image', 'image-shortcake' ),
+					'frameTitle'  => esc_attr__( 'Select Image', 'image-shortcake' ),
+				),
 
-					array(
-						'label'       => esc_html__( 'Image size', 'image-shortcake' ),
-						'attr'        => 'size',
-						'type'        => 'select',
-						'value'       => 'large',
-						'options'     => $sizes_available,
-					),
+				array(
+					'label'       => esc_html__( 'Image size', 'image-shortcake' ),
+					'attr'        => 'size',
+					'type'        => 'select',
+					'value'       => 'large',
+					'options'     => $sizes_available,
+				),
 
-					array(
-						'label'       => esc_html__( 'Alt', 'image-shortcake' ),
-						'attr'        => 'alt',
-						'type'        => 'text',
-						'encode'      => true,
-						'placeholder' => esc_attr__( 'Alt text for the image', 'image-shortcake' ),
-					),
+				array(
+					'label'       => esc_html__( 'Alt', 'image-shortcake' ),
+					'attr'        => 'alt',
+					'type'        => 'text',
+					'encode'      => true,
+					'placeholder' => esc_attr__( 'Alt text for the image', 'image-shortcake' ),
+				),
 
-					array(
-						'label'       => esc_html__( 'Caption', 'image-shortcake' ),
-						'attr'        => 'caption',
-						'type'        => 'text',
-						'encode'      => true,
-						'placeholder' => esc_attr__( 'Caption for the image', 'image-shortcake' ),
-					),
+				array(
+					'label'       => esc_html__( 'Caption', 'image-shortcake' ),
+					'attr'        => 'caption',
+					'type'        => 'text',
+					'encode'      => true,
+					'placeholder' => esc_attr__( 'Caption for the image', 'image-shortcake' ),
+				),
 
-					array(
-						'label'       => esc_html__( 'Alignment', 'image-shortcake' ),
-						'attr'        => 'align',
-						'type'        => 'select',
-						'value'       => 'aligncenter',
-						'options' => array(
-							'alignleft'   => esc_attr__( 'Left',   'image-shortcake' ),
-							'aligncenter' => esc_attr__( 'Center', 'image-shortcake' ),
-							'alignright'  => esc_attr__( 'Right',  'image-shortcake' ),
-							'alignnone'   => esc_attr__( 'None',   'image-shortcake' ),
-						),
-					),
-
-					array(
-						'label'       => esc_html__( 'Link to', 'image-shortcake' ),
-						'attr'        => 'linkto',
-						'type'        => 'select',
-						'value'       => get_option( 'image_default_link_type' ),
-						'options' => array(
-							'none'       => esc_attr__( 'None (no link)',          'image-shortcake' ),
-							'attachment' => esc_attr__( 'Link to attachment file', 'image-shortcake' ),
-							'file'       => esc_attr__( 'Link to file',            'image-shortcake' ),
-							'custom'     => esc_attr__( 'Custom link',             'image-shortcake' ),
-						),
-					),
-
-					array(
-						'label'       => esc_html__( 'Custom link', 'image-shortcake' ),
-						'attr'        => 'url',
-						'type'        => 'text',
-						'placeholder' => esc_attr__( 'URL to link to (if above link is "custom")', 'image-shortcake' ),
+				array(
+					'label'       => esc_html__( 'Alignment', 'image-shortcake' ),
+					'attr'        => 'align',
+					'type'        => 'select',
+					'value'       => 'aligncenter',
+					'options' => array(
+						'alignleft'   => esc_attr__( 'Left',   'image-shortcake' ),
+						'aligncenter' => esc_attr__( 'Center', 'image-shortcake' ),
+						'alignright'  => esc_attr__( 'Right',  'image-shortcake' ),
+						'alignnone'   => esc_attr__( 'None',   'image-shortcake' ),
 					),
 				),
-			);
+
+				array(
+					'label'       => esc_html__( 'Link to', 'image-shortcake' ),
+					'attr'        => 'linkto',
+					'type'        => 'select',
+					'value'       => get_option( 'image_default_link_type' ),
+					'options' => array(
+						'none'       => esc_attr__( 'None (no link)',          'image-shortcake' ),
+						'attachment' => esc_attr__( 'Link to attachment file', 'image-shortcake' ),
+						'file'       => esc_attr__( 'Link to file',            'image-shortcake' ),
+						'custom'     => esc_attr__( 'Custom link',             'image-shortcake' ),
+					),
+				),
+
+				array(
+					'label'       => esc_html__( 'Custom link', 'image-shortcake' ),
+					'attr'        => 'url',
+					'type'        => 'text',
+					'placeholder' => esc_attr__( 'URL to link to (if above link is "custom")', 'image-shortcake' ),
+				),
+			),
+		);
 
 		/**
 		 * Filter the shortcode UI definition arguments
@@ -193,7 +193,7 @@ class Img_Shortcode {
 			$image_attr['src'] = esc_url( $attachment[0] );
 			$image_attr['width'] = intval( $attachment[1] );
 			$image_attr['height'] = intval( $attachment[2] );
-		} else if ( ! empty( $attr['src'] ) ) {
+		} elseif ( ! empty( $attr['src'] ) ) {
 			$image_attr['src'] = esc_url( $attr['src'] );
 		} else {
 			return; // An image without a src isn't much of an image
@@ -271,7 +271,7 @@ class Img_Shortcode {
 
 		if ( isset( $attributes['url'] ) ) {
 			$link_attrs['href'] = esc_url( $attributes['url'] );
-		} else if ( ! empty( $attributes['linkto'] ) && 'attachment' === $attributes['linkto'] ) {
+		} elseif ( ! empty( $attributes['linkto'] ) && 'attachment' === $attributes['linkto'] ) {
 			$link_attrs['href'] = get_permalink( $_id );
 		} elseif ( ! empty( $attributes['linkto'] ) && 'file' === $attributes['linkto'] ) {
 			$attachment_src = wp_get_attachment_image_src( $_id, 'full', false, $attributes );
@@ -287,7 +287,7 @@ class Img_Shortcode {
 			$html .= sanitize_key( $attr_name ) . '="' . esc_attr( $attr_value ) . '" ';
 		}
 
-		$html .= '>' . $img_tag .'</a>';
+		$html .= '>' . $img_tag . '</a>';
 
 		return $html;
 	}
@@ -321,7 +321,9 @@ class Img_Shortcode {
 
 		// Ensure the image has a width defined; caption shortcode will break otherwise.
 		if ( 0 === intval( $attributes['width'] ) ) {
-			if ( $_attachment_src = wp_get_attachment_image_src( $attributes['id'], $attributes['size'] ) ) {
+			$_attachment_src = wp_get_attachment_image_src( $attributes['id'], $attributes['size'] );
+
+			if ( $_attachment_src ) {
 				$attributes['width'] = $_attachment_src[1];
 			}
 		}

--- a/inc/class-wp-cli-img-shortcode-command.php
+++ b/inc/class-wp-cli-img-shortcode-command.php
@@ -35,9 +35,9 @@ class Image_Shortcake_Command extends WP_CLI_Command {
 	 */
 	public function migrate( $args, $assoc_args ) {
 
-		foreach ( array_filter( $args ) as $post_ID ) {
+		foreach ( array_filter( $args ) as $post_id ) {
 
-			$post = $this->fetcher->get_check( $post_ID );
+			$post = $this->fetcher->get_check( $post_id );
 
 			$_content = $post->post_content;
 
@@ -89,7 +89,7 @@ class Image_Shortcake_Command extends WP_CLI_Command {
 			global $wpdb;
 
 			// @codingStandardsIgnoreStart
-			$updated = $wpdb->update( $wpdb->posts, array( 'post_content' => $_content ), array( 'ID' => $post_ID ) );
+			$updated = $wpdb->update( $wpdb->posts, array( 'post_content' => $_content ), array( 'ID' => $post_id ) );
 			// @codingStandardsIgnoreEnd
 
 			if ( 1 === $updated ) {

--- a/phpcs.ruleset.xml
+++ b/phpcs.ruleset.xml
@@ -5,6 +5,7 @@
 	<rule ref="WordPress-VIP">
 		<exclude name="WordPress.CSRF.NonceVerification" />
 		<exclude name="WordPress.WhiteSpace.ControlStructureSpacing" />
+		<exclude name="WordPress.Files.FileName" />
 		<exclude name="WordPress.VIP.SuperGlobalInputUsage" />
 		<exclude name="WordPress.VIP.ValidatedSanitizedInput" />
 	</rule>

--- a/tests/test-img-shortcode-data-migration.php
+++ b/tests/test-img-shortcode-data-migration.php
@@ -68,7 +68,7 @@ class Test_Img_Shortcode_Data_Migration extends WP_UnitTestCase {
 
 		$this->assertContains( $img_tag, array_keys( $replacements ) );
 
-		$this->assertContains( 'attachment="' . $this->attachment_id .'"', $replacements[ $img_tag ] );
+		$this->assertContains( 'attachment="' . $this->attachment_id . '"', $replacements[ $img_tag ] );
 		$this->assertNotContains( 'src="', $replacements[ $img_tag ] );
 	}
 
@@ -90,7 +90,7 @@ class Test_Img_Shortcode_Data_Migration extends WP_UnitTestCase {
 		$replacements = Img_Shortcode_Data_Migration::find_img_tags_for_replacement_on_post( $post_id );
 
 		$this->assertNotContains( 'attachment="', $replacements[ $img_tag ] );
-		$this->assertContains( 'src="' . $this->image_src .'"', $replacements[ $img_tag ] );
+		$this->assertContains( 'src="' . $this->image_src . '"', $replacements[ $img_tag ] );
 
 	}
 
@@ -120,7 +120,7 @@ class Test_Img_Shortcode_Data_Migration extends WP_UnitTestCase {
 			$this->assertContains( $should_be_matched, array_keys( $replacements ) );
 		}
 
-		$this->assertContains( 'attachment="' . $this->attachment_id .'"', $replacements[ $img_tag ] );
+		$this->assertContains( 'attachment="' . $this->attachment_id . '"', $replacements[ $img_tag ] );
 		$this->assertNotContains( 'src="', $replacements[ $img_tag ] );
 
 		$this->assertContains( 'href="http://go.to/thislink/"', $replacements[ $img_tag_link_custom ] );
@@ -168,7 +168,7 @@ class Test_Img_Shortcode_Data_Migration extends WP_UnitTestCase {
 	 */
 	private function insert_attachment( $parent_post_id = 0, $image = null, $post_fields = array() ) {
 
-		$filename = rand_str().'.jpg';
+		$filename = rand_str() . '.jpg';
 		$contents = rand_str();
 
 		if ( $image ) {

--- a/tests/test-img-shortcode.php
+++ b/tests/test-img-shortcode.php
@@ -172,7 +172,7 @@ EOL;
 	 */
 	private function insert_attachment( $parent_post_id = 0, $image = null, $post_fields = array() ) {
 
-		$filename = rand_str().'.jpg';
+		$filename = rand_str() . '.jpg';
 		$contents = rand_str();
 
 		if ( $image ) {


### PR DESCRIPTION
Travis no longer supports testing against pre-installed PHP5.3, and we
don't have to either. Updating the build matrix so new tests can pass
(see https://github.com/wp-shortcake/image-shortcake/pull/78#issuecomment-327916238)